### PR TITLE
Fix missing copyright acknowledgement

### DIFF
--- a/README.md
+++ b/README.md
@@ -53,6 +53,7 @@ To start, open the file `types.xml`.
 
 MIT License
 
+Copyright (c) 2018 MrX13415  
 Copyright (c) 2021 by O. Jemineh
 
 Permission is hereby granted, free of charge, to any person obtaining a copy


### PR DESCRIPTION
Hi,

This might just be an honest mistake, but I have to say something about it.

Right now it comes across as if you claim this as your original work, because you've removed the original author's name from the copyright notice in README.md, which is just not done. You've clearly continued where someone else left off, which is fine, the license allows that. And thank you for contributing. But you've removed the name of the original author from the license which states that the '_the above copyright notice and this permission notice shall be included in all copies or substantial portions of the Software_'. And: it is just right to acknowledge the other person.

As can be seen from the following files, even the project GUIDs are the same, which kind of proves the continuation of someone else's effort:
https://github.com/MrX13415/DayZEditor/blob/master/DayZLootEdit.sln
https://github.com/ojemineh/DayZLootEdit/blob/master/DayZLootEdit.sln

Would you be so kind to include the original author and add yourself as well as described below?
https://opensource.stackexchange.com/questions/8853/can-i-change-the-copyright-holder-name-and-year-of-an-mit-license

Thank you.
